### PR TITLE
FIX issue with the time set to zero

### DIFF
--- a/iso8601.go
+++ b/iso8601.go
@@ -90,12 +90,21 @@ func Parse(inp []byte) (time.Time, error) {
 	var p = year
 
 	var i int
+
+	var lastnum uint
 parse:
 	for ; i < len(inp); i++ {
 		switch inp[i] {
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			c = c * 10
-			c += uint(inp[i]) - charStart
+			if p == day && uint(inp[i]) == 48 {
+				if lastnum == 48 {
+					c = 1
+				}
+				lastnum = 48
+			} else {
+				c += uint(inp[i]) - charStart
+			}
 
 			if p == millisecond {
 				nfraction++
@@ -104,8 +113,14 @@ parse:
 			if p < second {
 				switch p {
 				case year:
+					if c == 0 {
+						c = 1
+					}
 					Y = c
 				case month:
+					if c == 0 {
+						c = 1
+					}
 					M = c
 				default:
 					return time.Time{}, newUnexpectedCharacterError(inp[i])

--- a/json_test.go
+++ b/json_test.go
@@ -31,6 +31,13 @@ var NullTestData = []byte(`
 }
 `)
 
+var ZeroedTestData = []byte(`
+{
+  "Ptr": "0000-00-00",
+  "Nptr": "0000-00-00"
+}
+`)
+
 var StructTest = TestCase{
 	Year: 2017, Month: 04, Day: 26,
 	Hour: 11, Minute: 13, Second: 04,
@@ -101,6 +108,13 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 	t.Run("null", func(t *testing.T) {
 		resp := new(TestAPIResponse)
 		if err := json.Unmarshal(NullTestData, resp); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("time zeroed", func(t *testing.T) {
+		resp := new(TestAPIResponse)
+		if err := json.Unmarshal(ZeroedTestData, resp); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
After paring a date with this value "0000-00-00"
internally the date is looking like  -0001-12-31 00:00:00 +0000 UTC
so for the round trip json Unmarshal/Marshal you can get this current error :
 json: error calling MarshalJSON for type iso8601.Time: Time.MarshalJSON: year outside of range [0,9999]

To keep is safe I use the default zeroed time of Go witch is 0001-01-01 00:00:00 +0000 UTC