### PR TITLE
Added support for omitted minutes and seconds

### DIFF
--- a/iso8601.go
+++ b/iso8601.go
@@ -110,7 +110,7 @@ parse:
 				nfraction++
 			}
 		case '-':
-			if p < second {
+			if p < hour {
 				switch p {
 				case year:
 					if c == 0 {
@@ -132,6 +132,10 @@ parse:
 			fallthrough
 		case '+':
 			switch p {
+			case hour:
+				h = c
+			case minute:
+				m = c
 			case second:
 				s = c
 			case millisecond:
@@ -175,6 +179,10 @@ parse:
 			p++
 		case 'Z':
 			switch p {
+			case hour:
+				h = c
+			case minute:
+				m = c
 			case second:
 				s = c
 			case millisecond:

--- a/iso8601_test.go
+++ b/iso8601_test.go
@@ -28,6 +28,18 @@ var cases = []TestCase{
 		Zone:        1,
 	},
 	{
+		Using: "2017-04-24T09:41+0100",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41,
+		Zone: 1,
+	},
+	{
+		Using: "2017-04-24T09+0100",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9,
+		Zone: 1,
+	},
+	{
 		Using: "2017-04-24T",
 		Year:  2017, Month: 4, Day: 24,
 	},
@@ -56,6 +68,18 @@ var cases = []TestCase{
 		Zone:        -1,
 	},
 	{
+		Using: "2017-04-24T09:41-01:00",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41,
+		Zone: -1,
+	},
+	{
+		Using: "2017-04-24T09-01:00",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9,
+		Zone: -1,
+	},
+	{
 		Using: "2017-04-24T09:41:34-0100",
 		Year:  2017, Month: 4, Day: 24,
 		Hour: 9, Minute: 41, Second: 34,
@@ -75,11 +99,35 @@ var cases = []TestCase{
 		Zone: 0,
 	},
 	{
+		Using: "2017-04-24T09:41Z",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41,
+		Zone: 0,
+	},
+	{
+		Using: "2017-04-24T09Z",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9,
+		Zone: 0,
+	},
+	{
 		Using: "2017-04-24T09:41:34.089",
 		Year:  2017, Month: 4, Day: 24,
 		Hour: 9, Minute: 41, Second: 34,
 		MilliSecond: 89,
 		Zone:        0,
+	},
+	{
+		Using: "2017-04-24T09:41",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41,
+		Zone: 0,
+	},
+	{
+		Using: "2017-04-24T09",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9,
+		Zone: 0,
 	},
 	{
 		Using: "2017-04-24T09:41:34.009",


### PR DESCRIPTION
ISO 8601 allows reduced-accuracy representations of time by omitting seconds, or
minutes and seconds. This PR adds support for such representations.