### PR TITLE
Specifically disallow timezones of "-00", "-00:00" and "-0000", per section ISO8601 section 3.4.2.

### DIFF
--- a/error.go
+++ b/error.go
@@ -9,6 +9,10 @@ var (
 	// ErrZoneCharacters indicates an incorrect amount of characters was passed to ParseISOZone.
 	ErrZoneCharacters = errors.New("iso8601: Expected between 3 and 6 characters for zone information")
 
+	// ErrInvalidZone indicates an invalid timezone per the standard that doesn't violate any specific
+	// character parsing rules.
+	ErrInvalidZone = errors.New("iso8601: Specified zone is invalid")
+
 	// ErrRemainingData indicates that there is extra data after a `Z` character.
 	ErrRemainingData = errors.New("iso8601: Unexepected remaining data after `Z`")
 

--- a/iso8601.go
+++ b/iso8601.go
@@ -80,6 +80,9 @@ func ParseISOZone(inp []byte) (*time.Location, error) {
 	if neg {
 		offset = -offset
 	}
+	if neg && offset == 0 {
+		return nil, ErrInvalidZone
+	}
 	return time.FixedZone("", offset), nil
 }
 

--- a/iso8601_test.go
+++ b/iso8601_test.go
@@ -16,7 +16,8 @@ type TestCase struct {
 	Second      int
 	MilliSecond int
 
-	Zone float64
+	Zone            float64
+	ShouldFailParse bool
 }
 
 var cases = []TestCase{
@@ -179,6 +180,39 @@ var cases = []TestCase{
 		MilliSecond: 502,
 		Zone:        5.75,
 	},
+	{
+		Using: "2017-04-24T09:41:34.502+00",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41, Second: 34,
+		MilliSecond: 502,
+		Zone:        0,
+	},
+	{
+		Using: "2017-04-24T09:41:34.502+0000",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41, Second: 34,
+		MilliSecond: 502,
+		Zone:        0,
+	},
+	{
+		Using: "2017-04-24T09:41:34.502+00:00",
+		Year:  2017, Month: 4, Day: 24,
+		Hour: 9, Minute: 41, Second: 34,
+		MilliSecond: 502,
+		Zone:        0,
+	},
+	{
+		Using:           "2017-04-24T09:41:34.502-00",
+		ShouldFailParse: true,
+	},
+	{
+		Using:           "2017-04-24T09:41:34.502-0000",
+		ShouldFailParse: true,
+	},
+	{
+		Using:           "2017-04-24T09:41:34.502-00:00",
+		ShouldFailParse: true,
+	},
 }
 
 func TestParse(t *testing.T) {
@@ -186,6 +220,9 @@ func TestParse(t *testing.T) {
 		t.Run(c.Using, func(t *testing.T) {
 			d, err := Parse([]byte(c.Using))
 			if err != nil {
+				if c.ShouldFailParse {
+					return
+				}
 				t.Fatal(err)
 			}
 			t.Log(d)
@@ -227,6 +264,9 @@ func TestParseString(t *testing.T) {
 		t.Run(c.Using, func(t *testing.T) {
 			d, err := ParseString(c.Using)
 			if err != nil {
+				if c.ShouldFailParse {
+					return
+				}
 				t.Fatal(err)
 			}
 			t.Log(d)


### PR DESCRIPTION
Addresses #7 .  Includes tests for both + and - 0 timezones.