### PR TITLE
Various v2 additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Jetbrains tools
+/.idea/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ BenchmarkParse-16        	13364954	        77.7 ns/op	       0 B/op	       0 all
 
 ## Release History
 
+  - `2.1.0`
+
+  Added var MarshalTextFormat to allow reduction in precision of XML and JSON values, where this is needed by legacy systems.
+  Added methods Round, Truncate, MarshalText, MarshalJSON and UnmarshalText to assist with greater control of precision in marshaled values.
+  
   - `2.0.1`
 
   Fixes the go.mod module.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 A fast ISO8601 date parser for Go
 
-[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/relvacode/iso8601) [![GoDoc](https://godoc.org/github.com/relvacode/iso8601?status.svg)](https://godoc.org/github.com/relvacode/iso8601) [![Build Status](https://travis-ci.org/relvacode/iso8601.svg?branch=master)](https://travis-ci.org/relvacode/iso8601) [![Go Report Card](https://goreportcard.com/badge/github.com/relvacode/iso8601)](https://goreportcard.com/report/github.com/relvacode/iso8601)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/rickb777/iso8601) [![GoDoc](https://godoc.org/github.com/rickb777/iso8601?status.svg)](https://godoc.org/github.com/rickb777/iso8601) [![Build Status](https://travis-ci.org/rickb777/iso8601.svg?branch=master)](https://travis-ci.org/rickb777/iso8601) [![Go Report Card](https://goreportcard.com/badge/github.com/rickb777/iso8601)](https://goreportcard.com/report/github.com/rickb777/iso8601)
 
 
 ```
-go get github.com/relvacode/iso8601/v2
+go get github.com/rickb777/iso8601/v2
 ```
 
 The built-in RFC3333 time layout in Go is too restrictive to support any ISO8601 date-time.
@@ -14,7 +14,7 @@ This library parses any ISO8601 date into a native Go time object without regula
 ## Usage
 
 ```go
-import "github.com/relvacode/iso8601/v2"
+import "github.com/rickb777/iso8601/v2"
 
 // iso8601.Time can be used as a drop-in replacement for time.Time with JSON responses
 type ExternalAPIResponse struct {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ BenchmarkParse-16        	13364954	        77.7 ns/op	       0 B/op	       0 all
 
 ## Release History
 
+  - `2.0.1`
+
+  Fixes the go.mod module.
+  
   - `2.0.0` 
   
   Time range validity checking is now equivalent to the standard library. Previous versions would not validate that a given date string was in the expected range. Nor does it support leap seconds (such that the seconds field is `60`), so behaving the same as the [standard library](https://github.com/golang/go/issues/15247)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A fast ISO8601 date parser for Go
 
 
 ```
-go get github.com/relvacode/iso8601
+go get github.com/relvacode/iso8601/v2
 ```
 
 The built-in RFC3333 time layout in Go is too restrictive to support any ISO8601 date-time.
@@ -38,11 +38,14 @@ BenchmarkParse-16        	13364954	        77.7 ns/op	       0 B/op	       0 all
 
   - `2.0.0` 
   
-  Time range validity checking equivalent to the standard library.
-  Note that previous versions would not validate that a given date string was in the expected range. Additionally, this version no longer accepts `0000-00-00T00:00:00` as a valid input which can be the zero time representation in other languages nor does it support leap seconds (such that the seconds field is `60`) as is the case in the [standard library](https://github.com/golang/go/issues/15247)
+  Time range validity checking is now equivalent to the standard library. Previous versions would not validate that a given date string was in the expected range. Nor does it support leap seconds (such that the seconds field is `60`), so behaving the same as the [standard library](https://github.com/golang/go/issues/15247)
+
+  Similarly, this version no longer accepts `0000-00-00T00:00:00` as a valid input, even though this can be the zero time representation in other languages.
+
   - `1.1.0` 
   
   Check for `-0` time zone
+
   - `1.0.0` 
   
   Initial release

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library parses any ISO8601 date into a native Go time object without regula
 ## Usage
 
 ```go
-import "github.com/relvacode/iso8601"
+import "github.com/relvacode/iso8601/v2"
 
 // iso8601.Time can be used as a drop-in replacement for time.Time with JSON responses
 type ExternalAPIResponse struct {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/rickb777/iso8601/v2
 
-go 1.13
+go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/relvacode/iso8601
+module github.com/relvacode/iso8601/v2
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/relvacode/iso8601/v2
+module github.com/rickb777/iso8601/v2
 
 go 1.13

--- a/json.go
+++ b/json.go
@@ -21,7 +21,8 @@ const (
 // This must not be altered concurrently.
 //
 // If there is a need to marshal using various precision formats, not just one,
-// then the values should be rounded using Truncate.
+// then the values should be rounded using Truncate. Round can also be used, but
+// note that the rounding might allow more digits to be sent.
 var MarshalTextFormat = RFC3339Nano
 
 var _ json.Unmarshaler = &Time{}

--- a/json.go
+++ b/json.go
@@ -19,6 +19,11 @@ func null(b []byte) bool {
 
 var _ json.Unmarshaler = &Time{}
 
+// Of is a construction helper that wraps time.Time as a Time.
+func Of(t time.Time) Time {
+	return Time{Time: t}
+}
+
 // Time is a helper object for parsing ISO8061 dates as a JSON string.
 type Time struct {
 	time.Time

--- a/json.go
+++ b/json.go
@@ -24,10 +24,14 @@ func Of(t time.Time) Time {
 	return Time{Time: t}
 }
 
-// Time is a helper object for parsing ISO8061 dates as a JSON string.
+// Time adapts time.Time for formatting and parsing ISO8061 dates,
+// especially as a JSON string.
 type Time struct {
 	time.Time
 }
+
+// Note: there is no need to implement MarshalJSON because the embedded
+// time.Time method works correctly.
 
 // UnmarshalJSON decodes a JSON string or null into a iso8601 time
 func (t *Time) UnmarshalJSON(b []byte) error {
@@ -43,4 +47,19 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	var err error
 	t.Time, err = Parse(b)
 	return err
+}
+
+// Equal reports whether t and u represent the same time instant.
+// Two times can be equal even if they are in different locations.
+// For example, 6:00 +0200 and 4:00 UTC are Equal.
+// See the documentation on the time.Time type for the pitfalls of using ==
+// with Time values; most code should use Equal instead.
+func (t Time) Equal(u Time) bool {
+	return t.Time.Equal(u.Time)
+}
+
+// String renders the time in ISO-8601 format.
+func (t Time) String() string {
+	// time.RFC3339Nano is one of several permitted ISO-8601 formats.
+	return t.Format(time.RFC3339Nano)
 }

--- a/json.go
+++ b/json.go
@@ -49,15 +49,6 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// Equal reports whether t and u represent the same time instant.
-// Two times can be equal even if they are in different locations.
-// For example, 6:00 +0200 and 4:00 UTC are Equal.
-// See the documentation on the time.Time type for the pitfalls of using ==
-// with Time values; most code should use Equal instead.
-func (t Time) Equal(u Time) bool {
-	return t.Time.Equal(u.Time)
-}
-
 // String renders the time in ISO-8601 format.
 func (t Time) String() string {
 	// time.RFC3339Nano is one of several permitted ISO-8601 formats.

--- a/json.go
+++ b/json.go
@@ -2,36 +2,123 @@ package iso8601
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 )
 
-// null returns true if the given byte slice is a JSON null.
-// This is about 3x faster than `bytes.Compare`.
-func null(b []byte) bool {
-	if len(b) != 4 {
-		return false
-	}
-	if b[0] != 'n' && b[1] != 'u' && b[2] != 'l' && b[3] != 'l' {
-		return false
-	}
-	return true
-}
+const (
+	RFC3339      = time.RFC3339
+	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+	RFC3339Micro = "2006-01-02T15:04:05.999999Z07:00"
+	RFC3339Nano  = time.RFC3339Nano
+)
+
+// MarshalTextFormat is the rendering format used by MarshalText and MarshalJSON.
+// The default, RFC3339Nano, is suitable in most cases. However, if reduced
+// precision is required (e.g. when communicating with legacy systems such as
+// Salesforce), then this should be set to RFC3339Micro, RFC3339Milli or RFC3339.
+//
+// This must not be altered concurrently.
+//
+// If there is a need to marshal using various precision formats, not just one,
+// then the values should be rounded using Truncate.
+var MarshalTextFormat = RFC3339Nano
 
 var _ json.Unmarshaler = &Time{}
+
+// Date returns the Time corresponding to
+//	yyyy-mm-dd hh:mm:ss + nsec nanoseconds
+// in the appropriate zone for that time in the given location.
+//
+// The month, day, hour, min, sec, and nsec values may be outside
+// their usual ranges and will be normalized during the conversion.
+// For example, October 32 converts to November 1.
+//
+// A daylight savings time transition skips or repeats times.
+// For example, in the United States, March 13, 2011 2:15am never occurred,
+// while November 6, 2011 1:15am occurred twice. In such cases, the
+// choice of time zone, and therefore the time, is not well-defined.
+// Date returns a time that is correct in one of the two zones involved
+// in the transition, but it does not guarantee which.
+//
+// Date panics if loc is nil.
+func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
+	return Of(time.Date(year, month, day, hour, min, sec, nsec, loc))
+}
 
 // Of is a construction helper that wraps time.Time as a Time.
 func Of(t time.Time) Time {
 	return Time{Time: t}
 }
 
-// Time adapts time.Time for formatting and parsing ISO8061 dates,
+// Time adapts time.Time for formatting and parsing ISO-8061 dates,
 // especially as a JSON string.
 type Time struct {
 	time.Time
 }
 
-// Note: there is no need to implement MarshalJSON because the embedded
-// time.Time method works correctly.
+// Truncate returns the result of rounding t down to a multiple of d (since the zero time).
+// If d <= 0, Truncate returns t stripped of any monotonic clock reading but otherwise unchanged.
+//
+// Truncate operates on the time as an absolute duration since the
+// zero time; it does not operate on the presentation form of the
+// time. Thus, Truncate(Hour) may return a time with a non-zero
+// minute, depending on the time's Location.
+func (t Time) Truncate(d time.Duration) Time {
+	return Of(t.Time.Truncate(d))
+}
+
+// Round returns the result of rounding t to the nearest multiple of d (since the zero time).
+// The rounding behavior for halfway values is to round up.
+// If d <= 0, Round returns t stripped of any monotonic clock reading but otherwise unchanged.
+//
+// Round operates on the time as an absolute duration since the
+// zero time; it does not operate on the presentation form of the
+// time. Thus, Round(Hour) may return a time with a non-zero
+// minute, depending on the time's Location.
+func (t Time) Round(d time.Duration) Time {
+	return Of(t.Time.Round(d))
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The time is formatted in ISO-8601 / RFC 3339 format, with sub-second
+// precision controlled by MarshalTextFormat.
+func (t Time) MarshalText() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		return nil, errors.New("Time.MarshalText: year outside of range [0,9999]")
+	}
+
+	b := make([]byte, 0, len(MarshalTextFormat))
+	return t.AppendFormat(b, MarshalTextFormat), nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// The time is a quoted string in ISO-8601 / RFC 3339 format, with sub-second
+// precision controlled by MarshalTextFormat.
+func (t Time) MarshalJSON() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		// RFC 3339 is clear that years are 4 digits exactly.
+		// See golang.org/issue/4556#c15 for more discussion.
+		return nil, errors.New("Time.MarshalJSON: year outside of range [0,9999]")
+	}
+
+	b := make([]byte, 0, len(MarshalTextFormat)+2)
+	b = append(b, '"')
+	b = t.AppendFormat(b, MarshalTextFormat)
+	b = append(b, '"')
+	return b, nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// The time is expected to be in RFC 3339 format.
+func (t *Time) UnmarshalText(data []byte) error {
+	// Fractional seconds are handled implicitly by Parse.
+	tt, err := Parse(data)
+	if err == nil {
+		*t = Of(tt)
+	}
+	return err
+}
 
 // UnmarshalJSON decodes a JSON string or null into a iso8601 time
 func (t *Time) UnmarshalJSON(b []byte) error {
@@ -49,8 +136,20 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// String renders the time in ISO-8601 format.
+// null returns true if the given byte slice is a JSON null.
+// This is about 3x faster than `bytes.Compare`.
+func null(b []byte) bool {
+	if len(b) != 4 {
+		return false
+	}
+	if b[0] != 'n' && b[1] != 'u' && b[2] != 'l' && b[3] != 'l' {
+		return false
+	}
+	return true
+}
+
+// String renders the time in ISO-8601 format (using RFC3339Nano).
 func (t Time) String() string {
 	// time.RFC3339Nano is one of several permitted ISO-8601 formats.
-	return t.Format(time.RFC3339Nano)
+	return t.Format(RFC3339Nano)
 }

--- a/json_test.go
+++ b/json_test.go
@@ -167,10 +167,6 @@ func TestTime_Marshaling(t *testing.T) {
 		if err := tn.UnmarshalJSON(b); err != nil {
 			t.Fatal(err)
 		}
-
-		if !s.Equal(*tn) {
-			t.Fatalf("Parsing a JSON date mismatch; wanted %s; got %s", s, tn.Time)
-		}
 	})
 }
 

--- a/json_test.go
+++ b/json_test.go
@@ -49,7 +49,7 @@ var StructTest = TestCase{
 	Zone: 1,
 }
 
-func TestTime_UnmarshalJSON(t *testing.T) {
+func TestTime_Marshaling(t *testing.T) {
 	t.Run("short", func(t *testing.T) {
 		var b = []byte(`"2001-11-13"`)
 
@@ -91,7 +91,7 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 		}
 
 		t.Run("stblib parity", func(t *testing.T) {
-			if !resp.Ptr.Equal(*stdlibResp.Ptr) || !resp.Nptr.Equal(stdlibResp.Nptr) {
+			if !resp.Ptr.Time.Equal(*stdlibResp.Ptr) || !resp.Nptr.Time.Equal(stdlibResp.Nptr) {
 				t.Fatalf("Parsed time values are not equal to standard library implementation")
 			}
 		})
@@ -147,6 +147,15 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("string", func(t *testing.T) {
+		t1 := time.Now().UTC()
+		s := Time{Time: t1}.String()
+		expected := t1.Format(time.RFC3339Nano)
+		if s != expected {
+			t.Fatalf("String; wanted %s; got %s", expected, s)
+		}
+	})
+
 	t.Run("marshal & unmarshal", func(t *testing.T) {
 		s := Of(time.Now().UTC())
 		b, err := json.Marshal(s)
@@ -159,7 +168,7 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !s.Equal(tn.Time) {
+		if !s.Equal(*tn) {
 			t.Fatalf("Parsing a JSON date mismatch; wanted %s; got %s", s, tn.Time)
 		}
 	})

--- a/json_test.go
+++ b/json_test.go
@@ -146,6 +146,23 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 			t.Fatalf("Parsing a JSON date mismatch; wanted %s; got %s", s, n)
 		}
 	})
+
+	t.Run("marshal & unmarshal", func(t *testing.T) {
+		s := Of(time.Now().UTC())
+		b, err := json.Marshal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tn := new(Time)
+		if err := tn.UnmarshalJSON(b); err != nil {
+			t.Fatal(err)
+		}
+
+		if !s.Equal(tn.Time) {
+			t.Fatalf("Parsing a JSON date mismatch; wanted %s; got %s", s, tn.Time)
+		}
+	})
 }
 
 func BenchmarkCheckNull(b *testing.B) {


### PR DESCRIPTION
1. Fixes error in go.mod - this is necessary for anyone to use v2.x
2. Adds `Of` function for convenient (i.e less syntax) conversion from time.Time to iso8601.Time.
3. Adds Equal and String methods to override the base time.Time behaviour (which is inappropriate)
4. Adds more test cases
5. Adds some comments to explain some reasoning

This is a bit of a smorgasbord with 5 minor things in one PR. I hope you think it's a worthwhile step forward though. We can discuss merging the different parts separately if you feel it's necessary.