### PR TITLE
Better ISO 8601 parsing

### DIFF
--- a/iso8601.go
+++ b/iso8601.go
@@ -215,6 +215,9 @@ parse:
 			Y = c
 			M = 1
 			d = 1
+		case month:
+			M = c
+			d = 1
 		case day:
 			d = c
 		case hour:

--- a/iso8601_test.go
+++ b/iso8601_test.go
@@ -251,6 +251,18 @@ var cases = []TestCase{
 		MilliSecond: 0,
 		Zone:        0,
 	},
+	{
+		Using: "2017-02",
+		Year:  2017, Month: 2, Day: 1, Hour: 0, Minute: 0, Second: 0,
+		MilliSecond: 0,
+		Zone:        0,
+	},
+	{
+		Using: "2017-02-16",
+		Year:  2017, Month: 2, Day: 16, Hour: 0, Minute: 0, Second: 0,
+		MilliSecond: 0,
+		Zone:        0,
+	},
 
 	// Invalid Parse Test Cases
 	{


### PR DESCRIPTION
There are several more valid date formats which this library does not support:
E.g. `2017-02` is a valid ISO 8601 date.

See:
https://en.wikipedia.org/wiki/ISO_8601
https://ijmacd.github.io/rfc3339-iso8601/


So that you know, this library has yet to support more valid date formats. See week dates or ordinal dates.

 