### PR TITLE
Parse ISO 8601 ordinal dates and reject malformed separators

### DIFF
--- a/iso8601.go
+++ b/iso8601.go
@@ -116,7 +116,9 @@ func ParseInLocation(inp []byte, loc *time.Location) (time.Time, error) {
 	)
 
 	var c uint
+	var n uint // digits accumulated since the last separator
 	var p = year
+	var ordinal bool // input is an ISO 8601 ordinal date (YYYY-DDD)
 
 	var i int
 
@@ -126,12 +128,17 @@ parse:
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			c = c * 10
 			c += uint(inp[i]) - charStart
+			n++
 
 			if p == millisecond {
 				nfraction++
 			}
 		case '-':
 			if p < hour {
+				if n == 0 {
+					// A dash with no preceding digits (e.g. `2020--01`).
+					return time.Time{}, newUnexpectedCharacterError(inp[i])
+				}
 				switch p {
 				case year:
 					Y = c
@@ -142,6 +149,7 @@ parse:
 				}
 				p++
 				c = 0
+				n = 0
 				continue
 			}
 			fallthrough
@@ -154,6 +162,15 @@ parse:
 			}
 
 			switch p {
+			case month:
+				// A three-digit component after the year is an ISO 8601 ordinal
+				// day-of-year (YYYY-DDD), not a month.
+				if n != 3 {
+					return time.Time{}, newUnexpectedCharacterError(inp[i])
+				}
+				M = 1
+				d = c
+				ordinal = true
 			case hour:
 				h = c
 			case minute:
@@ -166,6 +183,7 @@ parse:
 				return time.Time{}, newUnexpectedCharacterError(inp[i])
 			}
 			c = 0
+			n = 0
 			var err error
 			loc, err = ParseISOZone(inp[i:])
 			if err != nil {
@@ -173,31 +191,44 @@ parse:
 			}
 			break parse
 		case 'T', ' ':
-			if p != day {
+			switch {
+			case p == day:
+				d = c
+			case p == month && n == 3:
+				// ordinal day-of-year (YYYY-DDD) followed by a time
+				M = 1
+				d = c
+				ordinal = true
+			default:
 				return time.Time{}, newUnexpectedCharacterError(inp[i])
 			}
-			d = c
 			c = 0
-			p++
+			n = 0
+			p = hour
 		case ':':
+			if n == 0 {
+				// A colon with no preceding digits (e.g. `16::20`).
+				return time.Time{}, newUnexpectedCharacterError(inp[i])
+			}
 			switch p {
 			case hour:
 				h = c
 			case minute:
 				m = c
-			case second:
-				m = c
 			default:
+				// A colon after the seconds field (e.g. `16:20:45:`) is invalid.
 				return time.Time{}, newUnexpectedCharacterError(inp[i])
 			}
 			c = 0
+			n = 0
 			p++
 		case '.':
-			if p != second {
+			if p != second || n == 0 {
 				return time.Time{}, newUnexpectedCharacterError(inp[i])
 			}
 			s = c
 			c = 0
+			n = 0
 			p++
 		default:
 			return time.Time{}, newUnexpectedCharacterError(inp[i])
@@ -206,7 +237,13 @@ parse:
 
 	// Capture remaining data
 	// Sometimes a date can end without a non-integer character
-	if c > 0 {
+	if p == month && n == 3 {
+		// ISO 8601 ordinal date (YYYY-DDD): the three digits are the day of the
+		// year, not a month.
+		M = 1
+		d = c
+		ordinal = true
+	} else if c > 0 {
 		switch p {
 		case year:
 			Y = c
@@ -238,7 +275,7 @@ parse:
 	}
 
 	switch {
-	case M < 1 || M > 12: // Month 1-12
+	case !ordinal && (M < 1 || M > 12): // Month 1-12
 		return time.Time{}, &RangeError{
 			Value:   string(inp),
 			Element: "month",
@@ -246,7 +283,15 @@ parse:
 			Min:     1,
 			Max:     12,
 		}
-	case d < 1 || int(d) > daysIn(time.Month(M), int(Y)): // Day 1-daysIn(month, year)
+	case ordinal && (d < 1 || int(d) > daysInYear(int(Y))): // Ordinal day 1-365/366
+		return time.Time{}, &RangeError{
+			Value:   string(inp),
+			Element: "day",
+			Given:   int(d),
+			Min:     1,
+			Max:     daysInYear(int(Y)),
+		}
+	case !ordinal && (d < 1 || int(d) > daysIn(time.Month(M), int(Y))): // Day 1-daysIn(month, year)
 		return time.Time{}, &RangeError{
 			Value:   string(inp),
 			Element: "day",

--- a/ordinal_test.go
+++ b/ordinal_test.go
@@ -1,0 +1,120 @@
+package iso8601
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// ordinalCases covers ISO 8601 ordinal dates (YYYY-DDD), where the three digits
+// after the year are the day of the year rather than a month.
+var ordinalCases = []TestCase{
+	{Using: "2020-001", Year: 2020, Month: 1, Day: 1},
+	{Using: "2020-002", Year: 2020, Month: 1, Day: 2},
+	{Using: "2020-012", Year: 2020, Month: 1, Day: 12},
+	{Using: "2020-032", Year: 2020, Month: 2, Day: 1},
+	{Using: "2020-060", Year: 2020, Month: 2, Day: 29}, // leap year, day 60
+	{Using: "2020-061", Year: 2020, Month: 3, Day: 1},
+	{Using: "2020-100", Year: 2020, Month: 4, Day: 9},
+	{Using: "2020-366", Year: 2020, Month: 12, Day: 31}, // last day of a leap year
+	{Using: "2019-060", Year: 2019, Month: 3, Day: 1},   // non-leap year, day 60
+	{Using: "2019-365", Year: 2019, Month: 12, Day: 31},
+
+	// Ordinal dates with a time and/or zone.
+	{Using: "2020-012T10:20:30", Year: 2020, Month: 1, Day: 12, Hour: 10, Minute: 20, Second: 30},
+	{Using: "2020-012T10:20:30Z", Year: 2020, Month: 1, Day: 12, Hour: 10, Minute: 20, Second: 30},
+	{Using: "2020-012Z", Year: 2020, Month: 1, Day: 12},
+	{Using: "2020-012+05:00", Year: 2020, Month: 1, Day: 12, Zone: 5},
+
+	// Day of year out of range for the given year.
+	{Using: "2020-000", ShouldInvalidRange: true, RangeElementWhenInvalid: "day"},
+	{Using: "2020-367", ShouldInvalidRange: true, RangeElementWhenInvalid: "day"},
+	{Using: "2021-366", ShouldInvalidRange: true, RangeElementWhenInvalid: "day"}, // 2021 is not a leap year
+}
+
+func TestOrdinal(t *testing.T) {
+	for _, c := range ordinalCases {
+		t.Run(c.Using, func(t *testing.T) {
+			d, err := Parse([]byte(c.Using))
+			if c.CheckError(err, t) {
+				return
+			}
+			c.Check(d, t)
+		})
+	}
+}
+
+func TestOrdinalString(t *testing.T) {
+	for _, c := range ordinalCases {
+		t.Run(c.Using, func(t *testing.T) {
+			d, err := ParseString(c.Using)
+			if c.CheckError(err, t) {
+				return
+			}
+			c.Check(d, t)
+		})
+	}
+}
+
+// malformedInputs are inputs that were previously accepted and returned a
+// silently wrong time. Each must now fail to parse.
+var malformedInputs = []string{
+	"2020-01-02T16:20:45:99", // colon after the seconds field
+	"2020-01-02T16:20:45:",   // trailing colon after the seconds field
+	"2020-01-02T16::20",      // empty minute component
+	"2020-01-02T16:20:.5",    // empty second component
+	"2020--01-02",            // empty month component
+}
+
+func TestRejectMalformed(t *testing.T) {
+	for _, s := range malformedInputs {
+		t.Run(s, func(t *testing.T) {
+			if d, err := ParseString(s); err == nil {
+				t.Errorf("expected %q to fail parsing, got %s", s, d)
+			}
+		})
+	}
+}
+
+// ordinalReference converts a day of the year to a calendar month and day by
+// walking the months. It is deliberately independent of the parser's
+// time.Date based normalisation so it can act as an oracle.
+func ordinalReference(year, doy int) (month, day int) {
+	month = 1
+	for {
+		dim := daysIn(time.Month(month), year)
+		if doy <= dim {
+			return month, doy
+		}
+		doy -= dim
+		month++
+	}
+}
+
+// TestOrdinalDayOfYear exhaustively checks every valid day of the year across
+// leap and non-leap years (including century years) against the reference
+// conversion, and checks that the day after the final day is out of range.
+func TestOrdinalDayOfYear(t *testing.T) {
+	for _, year := range []int{1900, 1999, 2000, 2019, 2020, 2021, 2024, 2100} {
+		max := 365
+		if isLeap(year) {
+			max = 366
+		}
+		for doy := 1; doy <= max; doy++ {
+			s := fmt.Sprintf("%04d-%03d", year, doy)
+			got, err := ParseString(s)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", s, err)
+			}
+			wantM, wantD := ordinalReference(year, doy)
+			if got.Year() != year || int(got.Month()) != wantM || got.Day() != wantD {
+				t.Errorf("%s = %04d-%02d-%02d; want %04d-%02d-%02d",
+					s, got.Year(), int(got.Month()), got.Day(), year, wantM, wantD)
+			}
+		}
+		s := fmt.Sprintf("%04d-%03d", year, max+1)
+		if _, err := ParseString(s); err == nil {
+			t.Errorf("%s: expected a day range error", s)
+		}
+	}
+}

--- a/time.go
+++ b/time.go
@@ -18,3 +18,12 @@ func daysIn(m time.Month, year int) int {
 	}
 	return daysInMonth[int(m)]
 }
+
+// daysInYear is the number of days in the given year, used to validate the
+// day-of-year of an ISO 8601 ordinal date.
+func daysInYear(year int) int {
+	if isLeap(year) {
+		return 366
+	}
+	return 365
+}


### PR DESCRIPTION
The parser silently returns the wrong time for some inputs because the state machine commits each field on a separator without tracking how many digits it read.

Ordinal dates (the valid ISO 8601 `YYYY-DDD` form, where `DDD` is the day of the year) are parsed as `YYYY-MM`:

```
2020-012  ->  2020-12-01   (should be 2020-01-12, the 12th day of 2020)
2020-002  ->  2020-02-01   (should be 2020-01-02)
2020-100  ->  error "month 100 is not in range"
```

Since this library exists to accept ISO 8601 forms that `time.Parse` is too strict for, I parse these correctly rather than reject them. A three-digit run after the year is treated as an ordinal day-of-year, converted through the same `time.Date` normalisation the package already relies on and validated against the length of the year (365/366). Date, date+time and date+zone forms all work (`2020-012`, `2020-012T10:20:30Z`, `2020-012+05:00`).

The same missing digit count let malformed input through with a silently wrong result. These now fail to parse, in the same direction as #31:

```
2020-01-02T16:20:45:99  ->  16:45:00.99   (colon after seconds: SS moved to minutes, 99 became a fraction)
2020-01-02T16:20:45:    ->  16:45:00
2020-01-02T16::20       ->  16:00:20      (empty minute)
2020-01-02T16:20:.5     ->  16:20:00.5    (empty second)
```

Existing leniency is unchanged: single-digit components (`2020-1-2`), reduced precision (`2017`, `2017-02`) and a trailing `.`/`T` parse as before.

`TestOrdinal`/`TestRejectMalformed` cover the cases above; `TestOrdinalDayOfYear` checks every day of the year across leap and non-leap years (including 1900/2000/2100) against an independent month-walking reference. `go test -race ./...`, `go vet ./...` and `gofmt -l .` are clean.
